### PR TITLE
C++11 Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,7 @@ set(SOURCE_FILES
 #################
 # CONFIGURE C/C++
 #################
-set(CMAKE_C_CXX_COMMON_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS "-u MAIN__ ${CMAKE_C_CXX_COMMON_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "-Wall -std=c++11")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(ExampleResources)
 include (GenerateExportHeader)
 
+cmake_minimum_required(VERSION 2.8)
 
 set(RESOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -101,8 +102,7 @@ set(SOURCE_FILES
 #################
 # CONFIGURE C/C++
 #################
-set(CMAKE_C_CXX_COMMON_FLAGS "-Wall -Wno-float-equal -Wno-undef -Wno-strict-aliasing -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-macros")
-set(CMAKE_C_FLAGS "-u MAIN__ -std=gnu99 -fopenmp ${CMAKE_C_CXX_COMMON_FLAGS}")
+set(CMAKE_C_CXX_COMMON_FLAGS "-Wall")
 set(CMAKE_CXX_FLAGS "-u MAIN__ ${CMAKE_C_CXX_COMMON_FLAGS} -std=c++11")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,13 @@ set(SOURCE_FILES
     ${CMAKE_CURRENT_BINARY_DIR}/ResourceEnums.h
 )
 
+#################
+# CONFIGURE C/C++
+#################
+set(CMAKE_C_CXX_COMMON_FLAGS "-Wall -Wno-float-equal -Wno-undef -Wno-strict-aliasing -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-macros")
+set(CMAKE_C_FLAGS "-u MAIN__ -std=gnu99 -fopenmp ${CMAKE_C_CXX_COMMON_FLAGS}")
+set(CMAKE_CXX_FLAGS "-u MAIN__ ${CMAKE_C_CXX_COMMON_FLAGS} -std=c++11")
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/cpp)
 


### PR DESCRIPTION
Added "-std=c++11" flag to CMakeLists.txt for compatibility with C++11 standards. This has been tested with g++ 4.9.1 and it works without any warning nor errors. 
